### PR TITLE
Partially fixed out-of-bounds memory access

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -275,6 +275,8 @@ static void ref_search (const pack_context_t *this, backref_t *candidate, int fa
 		for (size = 0; size <= LONG_RUN_SIZE && current + size < start + insize; size++) {
 			if (start[pos - start - size] != current[size]) break;
 		}
+        if(size > pos - start)
+            size -= size - (pos - start);
 		backref_candidate(candidate, pos - start, size, lz_rev);
 	}
 }


### PR DESCRIPTION
inhal can produce files that aren't recognized by exhal. They contain reverse backwards references with a size greater than their offset, apparently reading unrelated data in front of the buffer. This does not occur when -fast is passed to inhal, as code responsible for finding a reverse backref is skipped.
This might be because inhal uses an uninitialized value in line 276, as valgrind reports.

Steps to reproduce:

    ./exhal kdl1.gb 0x8952 dec.bin
    ./inhal -n dec.bin new.bin

when compiled with -DDEBUG_OUT, one might be able to read

    write_backref: writing backref to    7, size 16 (method 2)

Interestingly this specific line of code has existed forever, but i didn't have any issues with exhal until the latest changes. I'd suggest adding a check that reads

    if(pos - start < size)
        size -= size - (pos - start);

before the backref_candidate() call.