### PR TITLE
Fix condition for skipping back reference candidates

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -532,7 +532,7 @@ static void pack_optimal(pack_context_t *this, int fast) {
 		// check for a potential RLE
 		rle_check(this, &rle, fast);
 		// check for a potential back reference
-		if (rle.size < LONG_RUN_SIZE && inputsize >= 4)
+		if (rle.size < LONG_RUN_SIZE && inputsize - this->inpos >= 4)
 			ref_search(this, &backref, fast);
 		else backref.size = 0;
 		


### PR DESCRIPTION
`ref_search` assumes that the candidate it's looking for has a size of 4 or greater (since anything smaller would cause the back reference command to take up more space than the literal bytes). The condition for guarding against this in `pack_optimal` was typo'd to check the size of the entire file, rather than the amount of space left in the file.

Fixes #8. Admittedly I haven't tested this very much, but the file I had trouble with no longer complains in AddressSanitizer.